### PR TITLE
fix: update links to `eslint/js` repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
     - name: 🗣 Ask a Question, Discuss
-      url: https://github.com/eslint/espree/discussions
+      url: https://github.com/eslint/js/discussions
       about: Get help using ESLint

--- a/packages/eslint-scope/README.md
+++ b/packages/eslint-scope/README.md
@@ -1,6 +1,6 @@
 [![npm version](https://img.shields.io/npm/v/eslint-scope.svg)](https://www.npmjs.com/package/eslint-scope)
 [![Downloads](https://img.shields.io/npm/dm/eslint-scope.svg)](https://www.npmjs.com/package/eslint-scope)
-[![Build Status](https://github.com/eslint/eslint-scope/workflows/CI/badge.svg)](https://github.com/eslint/eslint-scope/actions)
+[![Build Status](https://github.com/eslint/js/workflows/CI/badge.svg)](https://github.com/eslint/js/actions)
 
 # ESLint Scope
 
@@ -75,7 +75,7 @@ estraverse.traverse(ast, {
 
 ## Contributing
 
-Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](http://eslint.org/docs/developer-guide/contributing), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/eslint-scope/issues).
+Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](http://eslint.org/docs/developer-guide/contributing), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
 
 ## Security Policy
 

--- a/packages/eslint-scope/package.json
+++ b/packages/eslint-scope/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-scope",
   "description": "ECMAScript scope analyzer for ESLint",
-  "homepage": "http://github.com/eslint/eslint-scope",
+  "homepage": "https://github.com/eslint/js/blob/main/packages/eslint-scope/README.md",
   "main": "./dist/eslint-scope.cjs",
   "type": "module",
   "exports": {
@@ -15,10 +15,10 @@
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
-  "repository": "eslint/eslint-scope",
+  "repository": "eslint/js",
   "funding": "https://opencollective.com/eslint",
   "bugs": {
-    "url": "https://github.com/eslint/eslint-scope/issues"
+    "url": "https://github.com/eslint/js/issues"
   },
   "license": "BSD-2-Clause",
   "scripts": {

--- a/packages/espree/README.md
+++ b/packages/espree/README.md
@@ -1,6 +1,6 @@
 [![npm version](https://img.shields.io/npm/v/espree.svg)](https://www.npmjs.com/package/espree)
 [![npm downloads](https://img.shields.io/npm/dm/espree.svg)](https://www.npmjs.com/package/espree)
-[![Build Status](https://github.com/eslint/espree/workflows/CI/badge.svg)](https://github.com/eslint/espree/actions)
+[![Build Status](https://github.com/eslint/js/workflows/CI/badge.svg)](https://github.com/js/espree/actions)
 [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=9348450)](https://www.bountysource.com/trackers/9348450-eslint?utm_source=9348450&utm_medium=shield&utm_campaign=TRACKER_BADGE)
 
 # Espree
@@ -173,7 +173,7 @@ Espree may also deviate from Esprima in the interface it exposes.
 
 ## Contributing
 
-Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](http://eslint.org/docs/developer-guide/contributing), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/espree/issues).
+Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](http://eslint.org/docs/developer-guide/contributing), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
 
 Espree is licensed under a permissive BSD 2-clause license.
 

--- a/packages/espree/docs/README.md
+++ b/packages/espree/docs/README.md
@@ -1,6 +1,6 @@
 [![npm version](https://img.shields.io/npm/v/espree.svg)](https://www.npmjs.com/package/espree)
 [![npm downloads](https://img.shields.io/npm/dm/espree.svg)](https://www.npmjs.com/package/espree)
-[![Build Status](https://github.com/eslint/espree/workflows/CI/badge.svg)](https://github.com/eslint/espree/actions)
+[![Build Status](https://github.com/eslint/js/workflows/CI/badge.svg)](https://github.com/eslint/js/actions)
 [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=9348450)](https://www.bountysource.com/trackers/9348450-eslint?utm_source=9348450&utm_medium=shield&utm_campaign=TRACKER_BADGE)
 
 # Espree
@@ -173,7 +173,7 @@ Espree may also deviate from Esprima in the interface it exposes.
 
 ## Contributing
 
-Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](http://eslint.org/docs/developer-guide/contributing), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/espree/issues).
+Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](http://eslint.org/docs/developer-guide/contributing), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
 
 Espree is licensed under a permissive BSD 2-clause license.
 

--- a/packages/espree/docs/index.html
+++ b/packages/espree/docs/index.html
@@ -133,7 +133,7 @@
     <script>
       window.$docsify = {
         name: 'espree',
-        repo: 'eslint/espree',
+        repo: 'eslint/js',
         loadSidebar: true,
         subMaxLevel: 3,
         maxLevel: 3,
@@ -161,10 +161,10 @@
               if (/githubusercontent\.com/.test(vm.route.file)) {
                 url = vm.route.file
                   .replace('raw.githubusercontent.com', 'github.com')
-                  .replace(/\/master/, '/blob/master')
+                  .replace(/\/main/, '/blob/main')
               } else {
                 url =
-                  'https://github.com/eslint/espree/blob/master/' +
+                  'https://github.com/eslint/js/blob/main/' +
                   vm.route.file
               }
               var editHtml = '[:paperclip: Edit Document](' + url + ')\n'

--- a/packages/espree/package.json
+++ b/packages/espree/package.json
@@ -2,7 +2,7 @@
   "name": "espree",
   "description": "An Esprima-compatible JavaScript parser built on Acorn",
   "author": "Nicholas C. Zakas <nicholas+npm@nczconsulting.com>",
-  "homepage": "https://github.com/eslint/espree",
+  "homepage": "https://github.com/eslint/js/blob/main/packages/espree/README.md",
   "main": "dist/espree.cjs",
   "type": "module",
   "exports": {
@@ -25,9 +25,9 @@
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
-  "repository": "eslint/espree",
+  "repository": "eslint/js",
   "bugs": {
-    "url": "https://github.com/eslint/espree/issues"
+    "url": "https://github.com/eslint/js/issues"
   },
   "funding": "https://opencollective.com/eslint",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
This PR updates several links to match the new monorepo name and structure.