### PR TITLE
docs: update links to eslint-visitor-keys repo

### DIFF
--- a/packages/eslint-scope/README.md
+++ b/packages/eslint-scope/README.md
@@ -35,7 +35,7 @@ In order to analyze scope, you'll need to have an [ESTree](https://github.com/es
   * `impliedStrict` (default: `false`) - Set to `true` to evaluate the code in strict mode even outside of modules and without `"use strict"`.
   * `ecmaVersion` (default: `5`) - The version of ECMAScript to use to evaluate the code.
   * `sourceType` (default: `"script"`) - The type of JavaScript file to evaluate. Change to `"module"` for ECMAScript module code.
-  * `childVisitorKeys` (default: `null`) - An object with visitor key information (like [`eslint-visitor-keys`](https://github.com/eslint/eslint-visitor-keys)). Without this, `eslint-scope` finds child nodes to visit algorithmically. Providing this option is a performance enhancement.
+  * `childVisitorKeys` (default: `null`) - An object with visitor key information (like [`eslint-visitor-keys`](https://github.com/eslint/js/tree/main/packages/eslint-visitor-keys)). Without this, `eslint-scope` finds child nodes to visit algorithmically. Providing this option is a performance enhancement.
   * `fallback` (default: `"iteration"`) - The strategy to use when `childVisitorKeys` is not specified. May be a function.
 
 Example:

--- a/packages/eslint-visitor-keys/README.md
+++ b/packages/eslint-visitor-keys/README.md
@@ -87,7 +87,7 @@ console.log(evk.unionWith({
 
 ## 📰 Change log
 
-See [GitHub releases](https://github.com/eslint/eslint-visitor-keys/releases).
+See [GitHub releases](https://github.com/eslint/js/releases).
 
 ## 🍻 Contributing
 

--- a/packages/espree/README.md
+++ b/packages/espree/README.md
@@ -114,7 +114,7 @@ Returns the current `espree` version
 
 ### `VisitorKeys`
 
-Returns all visitor keys for traversing the AST from [eslint-visitor-keys](https://github.com/eslint/eslint-visitor-keys)
+Returns all visitor keys for traversing the AST from [eslint-visitor-keys](https://github.com/eslint/js/tree/main/packages/eslint-visitor-keys)
 
 ### `latestEcmaVersion`
 

--- a/packages/espree/docs/README.md
+++ b/packages/espree/docs/README.md
@@ -114,7 +114,7 @@ Returns the current `espree` version
 
 ### `VisitorKeys`
 
-Returns all visitor keys for traversing the AST from [eslint-visitor-keys](https://github.com/eslint/eslint-visitor-keys)
+Returns all visitor keys for traversing the AST from [eslint-visitor-keys](https://github.com/eslint/js/tree/main/packages/eslint-visitor-keys)
 
 ### `latestEcmaVersion`
 


### PR DESCRIPTION
Updated links to the archived `eslint/eslint-visitor-keys` repo so they point to the `eslint/js` monorepo.