### PR TITLE
chore: bump eslint-visitor-keys typescript to 5.4.2

### DIFF
--- a/packages/eslint-visitor-keys/package.json
+++ b/packages/eslint-visitor-keys/package.json
@@ -39,7 +39,7 @@
     "rollup": "^2.70.0",
     "rollup-plugin-dts": "^4.2.3",
     "tsd": "^0.19.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.4.2"
   },
   "scripts": {
     "build": "npm run build:cjs && npm run build:types",


### PR DESCRIPTION
#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Deduplicates the `typescript` dependency between `eslint-scope` and `eslint-visitor-keys`.

#### What changes did you make? (Give an overview)

Updates `eslint-visitor-keys` to the same version as `eslint-scope`: `^5.4.2`.

#### Related Issues

This should fix the build failures in e.g. https://github.com/eslint/js/actions/runs/11017802958/job/30596589705?pr=631:

```plaintext
Error: npm error ../../node_modules/@types/node/stream/web.d.ts(469,56): error TS1005: '?' expected.
Error: npm error tsconfig.json(3,13): error TS6046: Argument for '--lib' option must be: 'es5', 'es6', 'es2015', 'es7', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'esnext', 'dom', 'dom.iterable', 'webworker', 'webworker.importscripts', 'webworker.iterable', 'scripthost', 'es2015.core', 'es2015.collection', 'es2015.generator', 'es2015.iterable', 'es2015.promise', 'es2015.proxy', 'es2015.reflect', 'es2015.symbol', 'es2015.symbol.wellknown', 'es2016.array.include', 'es2017.object', 'es2017.sharedmemory', 'es2017.string', 'es2017.intl', 'es2017.typedarrays', 'es2018.asyncgenerator', 'es2018.asynciterable', 'es2018.intl', 'es2018.promise', 'es2018.regexp', 'es2019.array', 'es2019.object', 'es2019.string', 'es2019.symbol', 'es2020.bigint', 'es2020.promise', 'es2020.sharedmemory', 'es2020.string', 'es2020.symbol.wellknown', 'es2020.intl', 'es2021.promise', 'es2021.string', 'es2021.weakref', 'es2021.intl', 'esnext.array', 'esnext.symbol', 'esnext.asynciterable', 'esnext.intl', 'esnext.bigint', 'esnext.string', 'esnext.promise', 'esnext.weakref'.
```

Note that `es2022` isn't on that list of supported libs. That's because TS 4.9 didn't yet support it.

#### Is there anything you'd like reviewers to focus on?


