### PR TITLE
fix: Remove node:assert dependency

### DIFF
--- a/packages/eslint-scope/lib/assert.js
+++ b/packages/eslint-scope/lib/assert.js
@@ -1,0 +1,17 @@
+/**
+ * @fileoverview Assertion utilities.
+ * @author Nicholas C. Zakas
+ */
+
+/**
+ * Throws an error if the given condition is not truthy.
+ * @param {boolean} condition The condition to check.
+ * @param {string} message The message to include with the error.
+ * @returns {void}
+ * @throws {Error} When the condition is not truthy.
+ */
+export function assert(condition, message = "Assertion failed.") {
+    if (!condition) {
+        throw new Error(message);
+    }
+}

--- a/packages/eslint-scope/lib/index.js
+++ b/packages/eslint-scope/lib/index.js
@@ -46,7 +46,7 @@
  * @module escope
  */
 
-import assert from "node:assert";
+import { assert } from "./assert.js";
 
 import ScopeManager from "./scope-manager.js";
 import Referencer from "./referencer.js";

--- a/packages/eslint-scope/lib/referencer.js
+++ b/packages/eslint-scope/lib/referencer.js
@@ -28,7 +28,7 @@ import Reference from "./reference.js";
 import Variable from "./variable.js";
 import PatternVisitor from "./pattern-visitor.js";
 import { Definition, ParameterDefinition } from "./definition.js";
-import assert from "node:assert";
+import { assert } from "./assert.js";
 
 const { Syntax } = estraverse;
 

--- a/packages/eslint-scope/lib/scope-manager.js
+++ b/packages/eslint-scope/lib/scope-manager.js
@@ -36,7 +36,7 @@ import {
     SwitchScope,
     WithScope
 } from "./scope.js";
-import assert from "node:assert";
+import { assert } from "./assert.js";
 
 /**
  * @constructor ScopeManager

--- a/packages/eslint-scope/lib/scope.js
+++ b/packages/eslint-scope/lib/scope.js
@@ -27,7 +27,7 @@ import estraverse from "estraverse";
 import Reference from "./reference.js";
 import Variable from "./variable.js";
 import { Definition } from "./definition.js";
-import assert from "node:assert";
+import { assert } from "./assert.js";
 
 const { Syntax } = estraverse;
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed `node:assert` as a dependency in `eslint-scope`, replacing it with a custom `assert` function.

#### Related Issues

Fixes #625 
Closes #626

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
