### PR TITLE
chore: remove assert from rollup external array

### DIFF
--- a/packages/eslint-scope/rollup.config.js
+++ b/packages/eslint-scope/rollup.config.js
@@ -1,6 +1,6 @@
 export default {
     input: "./lib/index.js",
-    external: ["assert", "estraverse", "esrecurse"],
+    external: ["estraverse", "esrecurse"],
     treeshake: false,
     output: {
         format: "cjs",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
As part of #633, the `assert` dependency was removed, so there’s no need to include it as an external dependency in the Rollup config.
#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
