### PR TITLE
feat: Option to track JSX components as references

### DIFF
--- a/packages/eslint-scope/README.md
+++ b/packages/eslint-scope/README.md
@@ -37,6 +37,7 @@ In order to analyze scope, you'll need to have an [ESTree](https://github.com/es
   * `sourceType` (default: `"script"`) - The type of JavaScript file to evaluate. Change to `"module"` for ECMAScript module code.
   * `childVisitorKeys` (default: `null`) - An object with visitor key information (like [`eslint-visitor-keys`](https://github.com/eslint/js/tree/main/packages/eslint-visitor-keys)). Without this, `eslint-scope` finds child nodes to visit algorithmically. Providing this option is a performance enhancement.
   * `fallback` (default: `"iteration"`) - The strategy to use when `childVisitorKeys` is not specified. May be a function.
+  * `jsx` (default: `false`) - Enables the tracking of JSX components as variable references.
 
 Example:
 

--- a/packages/eslint-scope/lib/index.js
+++ b/packages/eslint-scope/lib/index.js
@@ -121,6 +121,7 @@ function updateDeeply(target, override) {
  * (if ecmaVersion >= 5).
  * @param {string} [providedOptions.sourceType='script'] the source type of the script. one of 'script', 'module', and 'commonjs'
  * @param {number} [providedOptions.ecmaVersion=5] which ECMAScript version is considered
+ * @param {boolean} [providedOptions.jsx=false] support JSX references
  * @param {Object} [providedOptions.childVisitorKeys=null] Additional known visitor keys. See [esrecurse](https://github.com/estools/esrecurse)'s the `childVisitorKeys` option.
  * @param {string} [providedOptions.fallback='iteration'] A kind of the fallback in order to encounter with unknown node. See [esrecurse](https://github.com/estools/esrecurse)'s the `fallback` option.
  * @returns {ScopeManager} ScopeManager

--- a/packages/eslint-scope/lib/referencer.js
+++ b/packages/eslint-scope/lib/referencer.js
@@ -651,6 +651,7 @@ class Referencer extends esrecurse.Visitor {
     }
 
     JSXIdentifier(node) {
+
         if (this.scopeManager.__isJSXEnabled()) {
             this.currentScope().__referencing(node);
         }
@@ -670,10 +671,14 @@ class Referencer extends esrecurse.Visitor {
     }
 
     JSXOpeningElement(node) {
-        const name = node.name.name;
+        if (this.scopeManager.__isJSXEnabled()) {
 
-        if (this.scopeManager.__isJSXEnabled() && name[0].toUpperCase() === name[0]) {
-            this.currentScope().__referencing(node.name);
+            const nameNode = node.name;
+
+            // we only want to visit JSXIdentifier nodes if they are capitalized
+            if (nameNode.type !== "JSXIdentifier" || nameNode.name[0].toUpperCase() === nameNode.name[0]) {
+                this.visit(nameNode);
+            }
         }
 
         node.attributes.forEach(this.visit, this);

--- a/packages/eslint-scope/lib/referencer.js
+++ b/packages/eslint-scope/lib/referencer.js
@@ -674,9 +674,11 @@ class Referencer extends esrecurse.Visitor {
         if (this.scopeManager.__isJSXEnabled()) {
 
             const nameNode = node.name;
+            const isComponentName = nameNode.type === "JSXIdentifier" && nameNode.name[0].toUpperCase() === nameNode.name[0];
+            const isComponent = isComponentName || nameNode.type === "JSXMemberExpression";
 
             // we only want to visit JSXIdentifier nodes if they are capitalized
-            if (nameNode.type !== "JSXIdentifier" || nameNode.name[0].toUpperCase() === nameNode.name[0]) {
+            if (isComponent) {
                 this.visit(nameNode);
             }
         }
@@ -692,6 +694,11 @@ class Referencer extends esrecurse.Visitor {
 
     JSXExpressionContainer(node) {
         this.visit(node.expression);
+    }
+
+    JSXNamespacedName(node) {
+        this.visit(node.namespace);
+        this.visit(node.name);
     }
 }
 

--- a/packages/eslint-scope/lib/referencer.js
+++ b/packages/eslint-scope/lib/referencer.js
@@ -649,6 +649,51 @@ class Referencer extends esrecurse.Visitor {
 
         // do nothing.
     }
+
+    JSXIdentifier(node) {
+        if (this.scopeManager.__isJSXEnabled()) {
+            this.currentScope().__referencing(node);
+        }
+    }
+
+    JSXMemberExpression(node) {
+        if (this.scopeManager.__isJSXEnabled()) {
+            this.visit(node.object);
+        }
+    }
+
+    JSXElement(node) {
+        if (this.scopeManager.__isJSXEnabled()) {
+            this.visit(node.openingElement);
+            node.children.forEach(this.visit, this);
+        }
+    }
+
+    JSXOpeningElement(node) {
+        if (this.scopeManager.__isJSXEnabled()) {
+            const name = node.name.name;
+
+            if (name[0].toUpperCase() === name[0]) {
+                this.currentScope().__referencing(node.name);
+            }
+
+            node.attributes.forEach(this.visit, this);
+        }
+    }
+
+    JSXAttribute(node) {
+        if (this.scopeManager.__isJSXEnabled()) {
+            if (node.value) {
+                this.visit(node.value);
+            }
+        }
+    }
+
+    JSXExpressionContainer(node) {
+        if (this.scopeManager.__isJSXEnabled()) {
+            this.visit(node.expression);
+        }
+    }
 }
 
 export default Referencer;

--- a/packages/eslint-scope/lib/referencer.js
+++ b/packages/eslint-scope/lib/referencer.js
@@ -657,42 +657,36 @@ class Referencer extends esrecurse.Visitor {
     }
 
     JSXMemberExpression(node) {
-        if (this.scopeManager.__isJSXEnabled()) {
-            this.visit(node.object);
-        }
+        this.visit(node.object);
     }
 
     JSXElement(node) {
         if (this.scopeManager.__isJSXEnabled()) {
             this.visit(node.openingElement);
             node.children.forEach(this.visit, this);
+        } else {
+            this.visitChildren(node);
         }
     }
 
     JSXOpeningElement(node) {
-        if (this.scopeManager.__isJSXEnabled()) {
-            const name = node.name.name;
+        const name = node.name.name;
 
-            if (name[0].toUpperCase() === name[0]) {
-                this.currentScope().__referencing(node.name);
-            }
-
-            node.attributes.forEach(this.visit, this);
+        if (this.scopeManager.__isJSXEnabled() && name[0].toUpperCase() === name[0]) {
+            this.currentScope().__referencing(node.name);
         }
+
+        node.attributes.forEach(this.visit, this);
     }
 
     JSXAttribute(node) {
-        if (this.scopeManager.__isJSXEnabled()) {
-            if (node.value) {
-                this.visit(node.value);
-            }
+        if (node.value) {
+            this.visit(node.value);
         }
     }
 
     JSXExpressionContainer(node) {
-        if (this.scopeManager.__isJSXEnabled()) {
-            this.visit(node.expression);
-        }
+        this.visit(node.expression);
     }
 }
 

--- a/packages/eslint-scope/lib/referencer.js
+++ b/packages/eslint-scope/lib/referencer.js
@@ -652,7 +652,8 @@ class Referencer extends esrecurse.Visitor {
 
     JSXIdentifier(node) {
 
-        if (this.scopeManager.__isJSXEnabled()) {
+        // Special case: "this" should not count as a reference
+        if (this.scopeManager.__isJSXEnabled() && node.name !== "this") {
             this.currentScope().__referencing(node);
         }
     }

--- a/packages/eslint-scope/lib/scope-manager.js
+++ b/packages/eslint-scope/lib/scope-manager.js
@@ -59,6 +59,10 @@ class ScopeManager {
         return this.__options.ignoreEval;
     }
 
+    __isJSXEnabled() {
+        return this.__options.jsx === true;
+    }
+
     isGlobalReturn() {
         return this.__options.nodejsScope || this.__options.sourceType === "commonjs";
     }

--- a/packages/eslint-scope/lib/scope.js
+++ b/packages/eslint-scope/lib/scope.js
@@ -421,7 +421,7 @@ class Scope {
     __referencing(node, assign, writeExpr, maybeImplicitGlobal, partial, init) {
 
         // because Array element may be null
-        if (!node || node.type !== Syntax.Identifier) {
+        if (!node || (node.type !== Syntax.Identifier && node.type !== "JSXIdentifier")) {
             return;
         }
 

--- a/packages/eslint-scope/tests/jsx.js
+++ b/packages/eslint-scope/tests/jsx.js
@@ -29,13 +29,34 @@ describe("References:", () => {
             expect(myComponentRef.resolved).to.equal(scope.variables[0]);
         });
 
-        it("should handle JSX attributes as references", () => {
+        it("should handle JSX attributes as references with JSX enabled", () => {
             const ast = espree(`
             const value = "test";
             const MyComponent = () => <div attr={value}/>;
         `, "script", true);
 
             const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // value, MyComponent
+            expect(scope.references).to.have.length(2); // value def, MyComponent def
+            expect(scope.variables[0].references).to.have.length(2); // value def, value use
+            expect(scope.through).to.have.length(0); // attr should not be a reference
+
+            const valueRef = scope.references[0];
+
+            expect(valueRef.identifier.name).to.equal("value");
+            expect(valueRef.isWrite()).to.be.true;
+            expect(valueRef.resolved).to.equal(scope.variables[0]);
+        });
+
+        it("should handle JSX attributes as references with JSX disabled", () => {
+            const ast = espree(`
+            const value = "test";
+            const MyComponent = () => <div attr={value}/>;
+        `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: false });
             const scope = scopeManager.scopes[0];
 
             expect(scope.variables).to.have.length(2); // value, MyComponent

--- a/packages/eslint-scope/tests/jsx.js
+++ b/packages/eslint-scope/tests/jsx.js
@@ -399,6 +399,23 @@ describe("References:", () => {
             expect(myNamespaceRef.isWrite()).to.be.true;
             expect(myNamespaceRef.resolved).to.equal(scope.variables[0]);
         });
+        
+        it("should not treat any JSX identifiers as references with JSX disabled", () => {
+            const ast = espree(`
+                <MyComponent/>;
+                <MyComponent></MyComponent>;
+                <div/>;
+                <Obj.Prop/>;
+                <Obj:Prop/>;
+                <MyComponent Attr1={"red"} attr2={"green"}/>;
+            `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: false });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(0);
+            expect(scope.references).to.have.length(0);
+        });
 
     });
 

--- a/packages/eslint-scope/tests/jsx.js
+++ b/packages/eslint-scope/tests/jsx.js
@@ -47,6 +47,25 @@ describe("References:", () => {
             expect(myComponentRef.isRead()).to.be.true;
             expect(myComponentRef.resolved).to.equal(scope.variables[0]);
         });
+        
+        it("should not treat JSX identifiers in closing elements as references", () => {
+            const ast = espree(`
+                const MyComponent = () => <div/>;
+                const element = <MyComponent></MyComponent>;
+            `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // MyComponent, element
+            expect(scope.references).to.have.length(3); // MyComponent def, element def, MyComponent use
+
+            const myComponentRef = scope.references[2];
+
+            expect(myComponentRef.identifier.name).to.equal("MyComponent");
+            expect(myComponentRef.isRead()).to.be.true;
+            expect(myComponentRef.resolved).to.equal(scope.variables[0]);
+        });
 
         it("should handle JSX attributes as references with JSX enabled", () => {
             const ast = espree(`

--- a/packages/eslint-scope/tests/jsx.js
+++ b/packages/eslint-scope/tests/jsx.js
@@ -110,11 +110,9 @@ describe("References:", () => {
 
             const childRefs = scope.references.filter(ref => ref.identifier.name === "Child");
 
-            expect(childRefs).to.have.length(1); // 1 def + 2 uses
-            childRefs.slice(1).forEach(ref => {
-                expect(ref.isRead()).to.be.true;
-                expect(ref.resolved).to.equal(scope.variables[0]);
-            });
+            expect(childRefs).to.have.length(1); // 1 def
+            expect(childRefs[0].isWrite()).to.be.true;
+            expect(childRefs[0].resolved).to.equal(scope.variables[0]);
         });
 
         it("should handle JSX fragment references", () => {
@@ -154,11 +152,9 @@ describe("References:", () => {
 
             const childRefs = scope.references.filter(ref => ref.identifier.name === "Child");
 
-            expect(childRefs).to.have.length(1); // 1 def + 2 uses
-            childRefs.slice(1).forEach(ref => {
-                expect(ref.isRead()).to.be.true;
-                expect(ref.resolved).to.equal(scope.variables[0]);
-            });
+            expect(childRefs).to.have.length(1); // 1 def
+            expect(childRefs[0].isWrite()).to.be.true;
+            expect(childRefs[0].resolved).to.equal(scope.variables[0]);
         });
 
         it("no JSX equivalent: should handle JSX fragments with component children", () => {
@@ -181,11 +177,9 @@ describe("References:", () => {
 
             const childRefs = scope.references.filter(ref => ref.identifier.name === "Child");
 
-            expect(childRefs).to.have.length(1); // 1 def + 2 uses
-            childRefs.slice(1).forEach(ref => {
-                expect(ref.isRead()).to.be.true;
-                expect(ref.resolved).to.equal(scope.variables[0]);
-            });
+            expect(childRefs).to.have.length(1); // 1 def
+            expect(childRefs[0].isWrite()).to.be.true;
+            expect(childRefs[0].resolved).to.equal(scope.variables[0]);
         });
 
         it("should handle JSX spread attributes", () => {

--- a/packages/eslint-scope/tests/jsx.js
+++ b/packages/eslint-scope/tests/jsx.js
@@ -108,6 +108,48 @@ describe("References:", () => {
             expect(valueRef.isWrite()).to.be.true;
             expect(valueRef.resolved).to.equal(scope.variables[0]);
         });
+        
+        it("should handle identifiers in child JSX expression containers with JSX enabled", () => {
+            const ast = espree(`
+                const value = "test";
+                const MyComponent = () => <div>{value}</div>;
+            `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // value, MyComponent
+            expect(scope.references).to.have.length(2); // value def, MyComponent def
+            expect(scope.variables[0].references).to.have.length(2); // value def, value use
+            expect(scope.through).to.have.length(0);
+
+            const valueRef = scope.references[0];
+
+            expect(valueRef.identifier.name).to.equal("value");
+            expect(valueRef.isWrite()).to.be.true;
+            expect(valueRef.resolved).to.equal(scope.variables[0]);
+        });
+
+        it("should handle identifiers in child JSX expression containers with JSX disabled", () => {
+            const ast = espree(`
+                const value = "test";
+                const MyComponent = () => <div>{value}</div>;
+            `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: false });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // value, MyComponent
+            expect(scope.references).to.have.length(2); // value def, MyComponent def
+            expect(scope.variables[0].references).to.have.length(2); // value def, value use
+            expect(scope.through).to.have.length(0);
+
+            const valueRef = scope.references[0];
+
+            expect(valueRef.identifier.name).to.equal("value");
+            expect(valueRef.isWrite()).to.be.true;
+            expect(valueRef.resolved).to.equal(scope.variables[0]);
+        });
 
         it("should handle nested JSX component references", () => {
             const ast = espree(`

--- a/packages/eslint-scope/tests/jsx.js
+++ b/packages/eslint-scope/tests/jsx.js
@@ -1,0 +1,167 @@
+/**
+ * @fileoverview Tests for JSX reference tracking.
+ * @author Nicholas C. Zakas
+ */
+
+import { expect } from "chai";
+import espree from "./util/espree.js";
+import { analyze } from "../lib/index.js";
+
+describe("References:", () => {
+
+    describe("JSX References:", () => {
+        it("should treat JSX identifiers as references", () => {
+            const ast = espree(`
+            const MyComponent = () => <div/>;
+            const element = <MyComponent />;
+        `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // MyComponent, element
+            expect(scope.references).to.have.length(3); // MyComponent def, element def, MyComponent use
+
+            const myComponentRef = scope.references[2];
+
+            expect(myComponentRef.identifier.name).to.equal("MyComponent");
+            expect(myComponentRef.isRead()).to.be.true;
+            expect(myComponentRef.resolved).to.equal(scope.variables[0]);
+        });
+
+        it("should handle JSX attributes as references", () => {
+            const ast = espree(`
+            const value = "test";
+            const MyComponent = () => <div attr={value}/>;
+        `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // value, MyComponent
+            expect(scope.references).to.have.length(2); // value def, MyComponent def
+            expect(scope.variables[0].references).to.have.length(2); // value def, value use
+            expect(scope.through).to.have.length(0); // attr should not be a reference
+
+            const valueRef = scope.references[0];
+
+            expect(valueRef.identifier.name).to.equal("value");
+            expect(valueRef.isWrite()).to.be.true;
+            expect(valueRef.resolved).to.equal(scope.variables[0]);
+        });
+
+        it("should handle nested JSX component references", () => {
+            const ast = espree(`
+            const Child = () => <div/>;
+            const Parent = () => (
+                <div>
+                    <Child/>
+                    <Child/>
+                </div>
+            );
+        `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // Child, Parent
+            expect(scope.references).to.have.length(2); // Child, Parent
+            expect(scope.variables[0].references).to.have.length(3); // Child def, Child use x2
+
+            const childRefs = scope.references.filter(ref => ref.identifier.name === "Child");
+
+            expect(childRefs).to.have.length(1); // 1 def + 2 uses
+            childRefs.slice(1).forEach(ref => {
+                expect(ref.isRead()).to.be.true;
+                expect(ref.resolved).to.equal(scope.variables[0]);
+            });
+        });
+
+        it("should handle JSX fragment references", () => {
+            const ast = espree(`
+            const MyComponent = () => (
+                <>
+                    <div/>
+                    <div/>
+                </>
+            );
+        `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(1); // MyComponent
+            expect(scope.references).to.have.length(1); // MyComponent
+        });
+
+        it("should handle JSX fragments with component children", () => {
+            const ast = espree(`
+            const Child = () => <div/>;
+            const Parent = () => (
+                <>
+                    <Child/>
+                    <Child/>
+                </>
+            );
+        `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // Child, Parent
+            expect(scope.references).to.have.length(2); // Child, Parent
+            expect(scope.variables[0].references).to.have.length(3); // Child def, Child use x2
+
+            const childRefs = scope.references.filter(ref => ref.identifier.name === "Child");
+
+            expect(childRefs).to.have.length(1); // 1 def + 2 uses
+            childRefs.slice(1).forEach(ref => {
+                expect(ref.isRead()).to.be.true;
+                expect(ref.resolved).to.equal(scope.variables[0]);
+            });
+        });
+
+        it("should handle JSX spread attributes", () => {
+            const ast = espree(`
+                const props = { attr: "value" };
+                const MyComponent = () => <div {...props}/>;
+            `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // props, MyComponent
+            expect(scope.references).to.have.length(2); // props def, MyComponent def
+            expect(scope.variables[0].references).to.have.length(2); // props def, props use
+
+            const propsRef = scope.references[0];
+
+            expect(propsRef.identifier.name).to.equal("props");
+            expect(propsRef.isWrite()).to.be.true;
+            expect(propsRef.resolved).to.equal(scope.variables[0]);
+        });
+
+        it("should handle JSX spread attributes with destructuring", () => {
+            const ast = espree(`
+                const props = { attr: "value" };
+                const MyComponent = ({ attr }) => <div {...props}/>;
+            `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // props, MyComponent
+            expect(scope.references).to.have.length(2); // props def, MyComponent def
+            expect(scope.variables[0].references).to.have.length(2); // props def, props use
+
+            const propsRef = scope.references[0];
+
+            expect(propsRef.identifier.name).to.equal("props");
+            expect(propsRef.isWrite()).to.be.true;
+            expect(propsRef.resolved).to.equal(scope.variables[0]);
+        });
+
+    });
+
+
+});

--- a/packages/eslint-scope/tests/jsx.js
+++ b/packages/eslint-scope/tests/jsx.js
@@ -29,6 +29,25 @@ describe("References:", () => {
             expect(myComponentRef.resolved).to.equal(scope.variables[0]);
         });
 
+        it("no JSX equivalent: should treat JSX identifiers as references", () => {
+            const ast = espree(`
+            const MyComponent = () => "<div/>";
+            const element = MyComponent;
+        `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // MyComponent, element
+            expect(scope.references).to.have.length(3); // MyComponent def, element def, MyComponent use
+
+            const myComponentRef = scope.references[2];
+
+            expect(myComponentRef.identifier.name).to.equal("MyComponent");
+            expect(myComponentRef.isRead()).to.be.true;
+            expect(myComponentRef.resolved).to.equal(scope.variables[0]);
+        });
+
         it("should handle JSX attributes as references with JSX enabled", () => {
             const ast = espree(`
             const value = "test";
@@ -142,6 +161,33 @@ describe("References:", () => {
             });
         });
 
+        it("no JSX equivalent: should handle JSX fragments with component children", () => {
+            const ast = espree(`
+            const Child = () => <div/>;
+            const Parent = () => (
+                [
+                    Child,
+                    Child
+                ]
+            );
+        `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // Child, Parent
+            expect(scope.references).to.have.length(2); // Child, Parent
+            expect(scope.variables[0].references).to.have.length(3); // Child def, Child use x2
+
+            const childRefs = scope.references.filter(ref => ref.identifier.name === "Child");
+
+            expect(childRefs).to.have.length(1); // 1 def + 2 uses
+            childRefs.slice(1).forEach(ref => {
+                expect(ref.isRead()).to.be.true;
+                expect(ref.resolved).to.equal(scope.variables[0]);
+            });
+        });
+
         it("should handle JSX spread attributes", () => {
             const ast = espree(`
                 const props = { attr: "value" };
@@ -149,6 +195,26 @@ describe("References:", () => {
             `, "script", true);
 
             const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // props, MyComponent
+            expect(scope.references).to.have.length(2); // props def, MyComponent def
+            expect(scope.variables[0].references).to.have.length(2); // props def, props use
+
+            const propsRef = scope.references[0];
+
+            expect(propsRef.identifier.name).to.equal("props");
+            expect(propsRef.isWrite()).to.be.true;
+            expect(propsRef.resolved).to.equal(scope.variables[0]);
+        });
+
+        it("no JSX equivalent: should handle JSX spread attributes", () => {
+            const ast = espree(`
+                const props = { attr: "value" };
+                const MyComponent = () => [...props];
+            `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
             const scope = scopeManager.scopes[0];
 
             expect(scope.variables).to.have.length(2); // props, MyComponent
@@ -180,6 +246,64 @@ describe("References:", () => {
             expect(propsRef.identifier.name).to.equal("props");
             expect(propsRef.isWrite()).to.be.true;
             expect(propsRef.resolved).to.equal(scope.variables[0]);
+        });
+
+        it("no JSX equivalent: should handle JSX spread attributes with destructuring", () => {
+            const ast = espree(`
+                const props = { attr: "value" };
+                const MyComponent = ({ attr }) => [...props];
+            `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // props, MyComponent
+            expect(scope.references).to.have.length(2); // props def, MyComponent def
+            expect(scope.variables[0].references).to.have.length(2); // props def, props use
+
+            const propsRef = scope.references[0];
+
+            expect(propsRef.identifier.name).to.equal("props");
+            expect(propsRef.isWrite()).to.be.true;
+            expect(propsRef.resolved).to.equal(scope.variables[0]);
+        });
+
+        it("should handle JSX <obj.prop/> syntax", () => {
+            const ast = espree(`
+                const obj = { prop: () => <div/> };
+                const element = <obj.prop />;
+            `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6, jsx: true });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // obj, element
+            expect(scope.references).to.have.length(3); // obj def, element def, obj.prop use
+
+            const objRef = scope.references[2];
+
+            expect(objRef.identifier.name).to.equal("obj");
+            expect(objRef.isRead()).to.be.true;
+            expect(objRef.resolved).to.equal(scope.variables[0]);
+        });
+
+        it("no JSX equivalent: should handle JSX <obj.prop/> syntax", () => {
+            const ast = espree(`
+                const obj = { prop: () => <div/> };
+                const element = obj.prop;
+            `, "script", true);
+
+            const scopeManager = analyze(ast, { ecmaVersion: 6 });
+            const scope = scopeManager.scopes[0];
+
+            expect(scope.variables).to.have.length(2); // obj, element
+            expect(scope.references).to.have.length(3); // obj def, element def, obj.prop use
+
+            const objRef = scope.references[2];
+
+            expect(objRef.identifier.name).to.equal("obj");
+            expect(objRef.isRead()).to.be.true;
+            expect(objRef.resolved).to.equal(scope.variables[0]);
         });
 
     });

--- a/packages/eslint-scope/tests/util/espree.js
+++ b/packages/eslint-scope/tests/util/espree.js
@@ -28,13 +28,17 @@ import * as espree from "espree";
  * Parse into Espree AST.
  * @param {string} code The code
  * @param {"module"|"script"} [sourceType="module"] The source type
+ * @param {boolean} [jsx=false] The flag to enable JSX parsing
  * @returns {Object} The parsed Espree AST
  */
-export default function(code, sourceType = "module") {
+export default function(code, sourceType = "module", jsx = false) {
     return espree.parse(code, {
         range: true,
         ecmaVersion: 7,
-        sourceType
+        sourceType,
+        ecmaFeatures: {
+            jsx
+        }
     });
 }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Added a new `jsx` option to `analyze()`.
- Updated `Referencer` to track JSX references.
- Added tests to verify the behavior.

#### Related Issues

fixes #645


#### Is there anything you'd like reviewers to focus on?

Please double-check that I'm covering enough scenarios in the tests. I'm not very familiar with JSX, so it's possible I missed some cases.

<!-- markdownlint-disable-file MD004 -->
