### PR TITLE
chore: move CLI test tools to root level and update `package.json` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
     ]
   },
   "devDependencies": {
+    "c8": "^10.1.3",
     "eslint": "^9.11.1",
     "eslint-config-eslint": "^11.0.0",
     "eslint-plugin-chai-friendly": "^1.0.0",
     "globals": "^15.1.0",
     "got": "^14.4.1",
     "lint-staged": "^15.2.0",
+    "mocha": "^11.1.0",
     "yorkie": "^2.0.0"
   }
 }

--- a/packages/eslint-scope/package.json
+++ b/packages/eslint-scope/package.json
@@ -15,8 +15,13 @@
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
-  "repository": "eslint/js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eslint/js.git",
+    "directory": "packages/eslint-scope"
+  },
   "funding": "https://opencollective.com/eslint",
+  "keywords": ["eslint"],
   "bugs": {
     "url": "https://github.com/eslint/js/issues"
   },
@@ -45,12 +50,10 @@
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^8.7.0",
-    "c8": "^7.7.3",
     "chai": "^4.3.4",
     "eslint-release": "^3.2.0",
     "eslint-visitor-keys": "^4.2.0",
     "espree": "^10.3.0",
-    "mocha": "^9.0.1",
     "npm-license": "^0.3.3",
     "rollup": "^2.52.7",
     "shelljs": "^0.8.5",

--- a/packages/eslint-visitor-keys/package.json
+++ b/packages/eslint-visitor-keys/package.json
@@ -29,12 +29,9 @@
     "@types/estree": "^0.0.51",
     "@types/estree-jsx": "^0.0.1",
     "@typescript-eslint/parser": "^8.7.0",
-    "c8": "^7.11.0",
-    "chai": "^4.3.6",
     "eslint-release": "^3.2.0",
     "esquery": "^1.4.0",
     "json-diff": "^0.7.3",
-    "mocha": "^9.2.1",
     "opener": "^1.5.2",
     "rollup": "^4.22.4",
     "rollup-plugin-dts": "^6.1.1",
@@ -55,9 +52,13 @@
     "test:open-coverage": "c8 report --reporter lcov && opener coverage/lcov-report/index.html",
     "test:types": "tsd"
   },
-  "repository": "eslint/js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eslint/js.git",
+    "directory": "packages/eslint-visitor-keys"
+  },
   "funding": "https://opencollective.com/eslint",
-  "keywords": [],
+  "keywords": ["eslint"],
   "author": "Toru Nagashima (https://github.com/mysticatea)",
   "license": "Apache-2.0",
   "bugs": {

--- a/packages/espree/package.json
+++ b/packages/espree/package.json
@@ -25,7 +25,11 @@
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
-  "repository": "eslint/js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eslint/js.git",
+    "directory": "packages/espree"
+  },
   "bugs": {
     "url": "https://github.com/eslint/js/issues"
   },
@@ -40,10 +44,8 @@
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.3.0",
-    "c8": "^7.11.0",
     "eslint-release": "^3.2.0",
     "esprima-fb": "^8001.2001.0-dev-harmony-fb",
-    "mocha": "^9.2.2",
     "npm-run-all2": "^6.2.2",
     "rollup": "^2.79.1",
     "shelljs": "^0.8.5"
@@ -70,6 +72,6 @@
     "release:publish": "eslint-publish-release",
     "test": "npm-run-all -s test:*",
     "test:cjs": "mocha --color --reporter progress --timeout 30000 tests/lib/commonjs.cjs",
-    "test:esm": "c8 mocha --color --reporter progress --timeout 30000 'tests/lib/**/*.js'"
+    "test:esm": "c8 mocha --color --reporter progress --timeout 30000 tests/lib/**/*.js"
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Hello,

This PR moves CLI test tools (e.g., Mocha, c8) to the root `package.json` as `devDependencies` to streamline dependency management across the monorepo.

Also updated relevant `package.json` files in individual packages to remove redundant entries and ensure consistent setup.

Benefits of this change in a monorepo structure:

- Simplified management: Reduces duplication of dependencies across packages and makes upgrades easier.

- Consistency: Ensures all packages use the same versions of test tools, preventing version mismatch issues.

- Faster installs: Smaller and cleaner `node_modules` in individual packages lead to faster dependency installation times.

- Better CI performance: Centralized tooling simplifies build and test processes in CI environments.

#### What changes did you make? (Give an overview)

1. Moved `mocha` and `c8` to the root-level `package.json` as devDependencies.
1. Upgraded `mocha` and `c8` to the latest versions, as there were no breaking issues.
1. Updated the `repository` field in `package.json` to accurately reflect the monorepo structure.
1. Added a `keywords` field to `package.json` for better discoverability.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
