### PR TITLE
fix: order visitor keys for `ExportSpecifier` in source code order

### DIFF
--- a/packages/eslint-visitor-keys/lib/visitor-keys.js
+++ b/packages/eslint-visitor-keys/lib/visitor-keys.js
@@ -100,8 +100,8 @@ const KEYS = {
         "attributes"
     ],
     ExportSpecifier: [
-        "exported",
-        "local"
+        "local",
+        "exported"
     ],
     ExpressionStatement: [
         "expression"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Change visitation order for `ExportSpecifier` to source code order.

#### What changes did you make? (Give an overview)

Visit `local` before `exported`.

```js
export { local as exported };
```

#### Related Issues

Fixes #655.

#### Is there anything you'd like reviewers to focus on?

I've opened this PR before anyone's had time to look at issue #655. I hope that's not considered rude. I hope it might be useful for checking if this change would break any rules (I assume it won't).