### PR TITLE
chore: replace `npm-run-all2` with a native script

### DIFF
--- a/packages/espree/package.json
+++ b/packages/espree/package.json
@@ -46,7 +46,6 @@
     "@rollup/plugin-node-resolve": "^15.3.0",
     "eslint-release": "^3.2.0",
     "esprima-fb": "^8001.2001.0-dev-harmony-fb",
-    "npm-run-all2": "^6.2.2",
     "rollup": "^2.79.1",
     "shelljs": "^0.8.5"
   },
@@ -70,7 +69,7 @@
     "release:generate:beta": "eslint-generate-prerelease beta",
     "release:generate:rc": "eslint-generate-prerelease rc",
     "release:publish": "eslint-publish-release",
-    "test": "npm-run-all -s test:*",
+    "test": "npm run test:cjs && npm run test:esm",
     "test:cjs": "mocha --color --reporter progress --timeout 30000 tests/lib/commonjs.cjs",
     "test:esm": "c8 mocha --color --reporter progress --timeout 30000 tests/lib/**/*.js"
   }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hello,

In this PR, I've replaced `npm-run-all2` with a native script.

This PR resolves #660.

While reducing devDependencies may not be critical in package development, I believe it's a good practice for the following reasons:

1. Performance - Faster install times and a smaller `node_modules`.
2. Maintenance - Fewer tools to update and manage.
3. Cleaner CI/CD - Leaner builds and more reliable pipelines.
4. Smaller footprint - Less clutter in the project, which is especially important for shared libraries.

#### Related Issues

fixes: #660 

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
